### PR TITLE
Differentiate code for different kernel version

### DIFF
--- a/src/mac80211.c
+++ b/src/mac80211.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (C) 2016 Felix Fietkau <nbd@nbd.name>
  */
+#include <linux/version.h>
 #include <linux/sched.h>
 #include <linux/of.h>
 #include "mt76.h"
@@ -1559,6 +1560,9 @@ void mt76_wcid_cleanup(struct mt76_dev *dev, struct mt76_wcid *wcid)
 EXPORT_SYMBOL_GPL(mt76_wcid_cleanup);
 
 int mt76_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)	
+	unsigned int link_id,
+#endif
 		     int *dbm)
 {
 	struct mt76_phy *phy = hw->priv;

--- a/src/mt76.h
+++ b/src/mt76.h
@@ -6,6 +6,7 @@
 #ifndef __MT76_H
 #define __MT76_H
 
+#include <linux/version.h>
 #include <linux/kernel.h>
 #include <linux/io.h>
 #include <linux/spinlock.h>
@@ -1418,6 +1419,9 @@ void mt76_sta_pre_rcu_remove(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 int mt76_get_min_avg_rssi(struct mt76_dev *dev, bool ext_phy);
 
 int mt76_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)	
+	unsigned int link_id,
+#endif	
 		     int *dbm);
 int mt76_init_sar_power(struct ieee80211_hw *hw,
 			const struct cfg80211_sar_specs *sar);

--- a/src/mt7902/main.c
+++ b/src/mt7902/main.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: ISC
 /* Copyright (C) 2020 MediaTek Inc. */
 
+
+#include <linux/version.h>
 #include <linux/etherdevice.h>
 #include <linux/platform_device.h>
 #include <linux/pci.h>
@@ -380,7 +382,12 @@ void mt7921_roc_abort_sync(struct mt792x_dev *dev)
 {
 	struct mt792x_phy *phy = &dev->phy;
 
-	del_timer_sync(&phy->roc_timer);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&phy->roc_timer);
+#else
+    del_timer_sync(&phy->roc_timer);
+#endif
+
 	cancel_work_sync(&phy->roc_work);
 	if (test_and_clear_bit(MT76_STATE_ROC, &phy->mt76->state))
 		ieee80211_iterate_active_interfaces(mt76_hw(dev),
@@ -411,7 +418,11 @@ static int mt7921_abort_roc(struct mt792x_phy *phy, struct mt792x_vif *vif)
 {
 	int err = 0;
 
-	del_timer_sync(&phy->roc_timer);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&phy->roc_timer);
+#else
+    del_timer_sync(&phy->roc_timer);
+#endif
 	cancel_work_sync(&phy->roc_work);
 
 	mt792x_mutex_acquire(phy->dev);


### PR DESCRIPTION
I added a couple of changes for compiling also with the 6.15.x kernels.