### PR TITLE
wifi: mt76: mt7902: set MT7902_TXQ_FWDL to 16

### DIFF
--- a/src/mt7902/mt7902.h
+++ b/src/mt7902/mt7902.h
@@ -108,7 +108,7 @@ enum mt7902_txq_id {
 	MT7902_TXQ_BAND0,
 	MT7902_TXQ_BAND1,
 	MT7902_TXQ_MCU_WM = 15,
-	MT7902_TXQ_FWDL,
+	MT7902_TXQ_FWDL = 16,
 };
 
 enum mt7902_rxq_id {


### PR DESCRIPTION
Based on information in Xiaomi's "rodin" BSP
https://github.com/MiCode/MTK_kernel_modules/blob/bsp-rodin-v-oss/connectivity/wlan/core/gen4-mt79xx/chips/mt7902/mt7902.c#L376