### PR TITLE
wifi: mt76: mt7902: correct USB & SDIO devices

### DIFF
--- a/src/mt7902/sdio.c
+++ b/src/mt7902/sdio.c
@@ -17,7 +17,7 @@
 #include "mcu.h"
 
 static const struct sdio_device_id mt7902s_table[] = {
-	{ SDIO_DEVICE(SDIO_VENDOR_ID_MEDIATEK, 0x7901),
+	{ SDIO_DEVICE(SDIO_VENDOR_ID_MEDIATEK, 0x7902),
 		.driver_data = (kernel_ulong_t)MT7902_FIRMWARE_WM },
 	{ }	/* Terminating entry */
 };

--- a/src/mt7902/usb.c
+++ b/src/mt7902/usb.c
@@ -13,16 +13,7 @@
 #include "../mt76_connac2_mac.h"
 
 static const struct usb_device_id mt7902u_device_table[] = {
-	{ USB_DEVICE_AND_INTERFACE_INFO(0x0e8d, 0x7961, 0xff, 0xff, 0xff),
-		.driver_info = (kernel_ulong_t)MT7902_FIRMWARE_WM },
-	/* Comfast CF-952AX */
-	{ USB_DEVICE_AND_INTERFACE_INFO(0x3574, 0x6211, 0xff, 0xff, 0xff),
-		.driver_info = (kernel_ulong_t)MT7902_FIRMWARE_WM },
-	/* Netgear, Inc. [A8000,AXE3000] */
-	{ USB_DEVICE_AND_INTERFACE_INFO(0x0846, 0x9060, 0xff, 0xff, 0xff),
-		.driver_info = (kernel_ulong_t)MT7902_FIRMWARE_WM },
-	/* TP-Link TXE50UH */
-	{ USB_DEVICE_AND_INTERFACE_INFO(0x35bc, 0x0107, 0xff, 0xff, 0xff),
+	{ USB_DEVICE_AND_INTERFACE_INFO(0x0e8d, 0x7902, 0xff, 0xff, 0xff),
 		.driver_info = (kernel_ulong_t)MT7902_FIRMWARE_WM },
 	{ },
 };


### PR DESCRIPTION
Imported from Xiaomi's "rodin" BSP
https://github.com/MiCode/MTK_kernel_modules/blob/bsp-rodin-v-oss/connectivity/wlan/core/gen4-mt79xx/os/linux/hif/sdio/sdio.c#L182 https://github.com/MiCode/MTK_kernel_modules/blob/bsp-rodin-v-oss/connectivity/wlan/core/gen4-mt79xx/os/linux/hif/usb/usb.c#L133

Although to be fair, we haven't seen any cases of USB wifi with mt7902 or even devices with mt7902 SDIO so might as well just cleanup the source code to support PCIe only.